### PR TITLE
Readme rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ import thunk from 'redux-thunk';
 
 import { combineAsyncReducers, configureRags } from 'redux-rags';
 
-// ... import a few reducers, we'll use userReducer as an example
+// ... import a few reducers; we'll use userReducer as an example
 import userReducer from './userReducer';
 
 const createRootReducer = (dynamicReducers: Object = {}) => {

--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@
 
 Redux **R**educers, **A**ctions, and **G**etters: Simplified!
 
-TLDR: No need to create subreducers. Your Redux connection is handled by a single function
+TLDR: No need to create or connect subreducers for simple async requests. Your Redux connection is handled by a single function
 ```js
-const { actions: { load }, getters: { getData } } = ragFactory({ load });
+const rag = ragFactory({ load });
+const newLoad = rag.actions.load;
+const getData = rag.getters.getData;
 ```
 
 ## Motivation
@@ -27,62 +29,48 @@ similar actions and subreducers. But what if there were an easier way? What if w
 define that mini state machine once and re-use the logic with each kind of query? Well `redux-rags` is
 here to help!
 
+## Injecting a Subreducer?!
+Using Redux requires quite a lot of boilerplate. You need to create Actions and maybe Action Creators. You need to create Reducers and place them somewhere in the store, maybe as a part of another reducer. There are a myriad of tools out there to help you simplify this process, and we're adding another to the list! This one is built around the idea that there are some pieces of state that you would like to have stored outside of a particular rendering context, but don't want to go through all the migration work to create a custom reducer in the store for this data. You want to take advantage of the benefits of Redux without trudging through all the boilerplate.
+
+So what if you had a way to add subreducers to Redux? Then you could write code that generates the subreducer structures you use frequently and inject them! You could now start writing subreducers aimed at general cases of data interaction and vastly reduce the time it takes to migrate a piece of state to Redux. We've provided our most useful abstraction here, a simple data request lifecycle. Hopefully you can see the opportunities that injecting a subreducer provides and can use the code here as an example for how to start reusing your own subreducer logic.
+
+For more details, I encourage you to check out [this Medium article by Jimmy Shen on subreducer injection.](https://medium.com/@jimmy_shen/inject-reducer-arbitrarily-rather-than-top-level-for-redux-store-to-replace-reducer-fdc1060a6a7)
+
 ## Usage
 
-### Let's define our Redux interactions
+
+### Single File Redux Connection Example
 Here's how you'd interact with Redux for a data request. We're going to create the actions and
 automatically create and inject the subreducer. The returned `load` function will take the same
-arguments as the `load` function passed in, so you have complete control over what the `load`
-function is. Here we're going for a parameter-less fetch request, just for the sake of the example.
-We'll need to pass `actions`
-```js
-import { ragFactory } from 'redux-rags';
+arguments as the `load` function passed in, so you have control over the `load` thunk.
 
-const axiosLoadFaq = () => fetch('http://api.example.com/data.json');
-const { actions, getters } = ragFactory({ load: axiosLoadFaq });
+Here we want to hit an endpoint with the `userId` parameter. We'll avoid worrying about
+loading states or anything for now. The call to `ragFactory` creates the actions and injects
+the subreducer for us. Then this state information is stored in Redux, so when users return to the
+component they'll see the cached data. [Play with a similar example on CodeSandbox](https://codesandbox.io/s/vnn9pnp6vl)
 
-export {
-  loadFaq: actions.load,
-  getFaq: getters.getData,
-  getIsFaqLoading: getters.getIsLoading,
-};
-```
-
-#### Use that Data Request in a React Component
-Import the Getters and Action as you normally would and use them with `react-redux`.
 ```js
 import React from 'react';
 import { connect } from 'react-redux';
-import { loadFaq, getFaq, getIsFaqLoading } from './faqData';
-import Loading from './Loading';
-import FaqItem from './FaqItem';
+import { ragFactory } from 'redux-rags';
 
-class Faq extends React.Component {
-  componentDidMount() {
-    this.props.loadFaq();
-  }
-
-  render() {
-    const { isLoading, faqData } = this.props;
-    if (isLoading) {
-      return <Loading />;
-    }
-
-    return (
-      <React.Fragment>
-        {faqData.map((data, index) => <FaqItem key={index} data={data} />}
-      </React.Fragment>
-    )
-  }
-}
-
-const mapStateFromProps = state => ({
-  faqData: getFaq(state),
-  isLoading: getIsFaqLoading(state)
+// Pass load to factory, factory returns basically the same load that we can give to connect.
+const { actions: { load }, getters: { getData } } = ragFactory({
+  load: (userId) => axios.get('/users', { userId })
 });
 
-export default connect(mapStateFromProps, { loadFaq })(Faq);
+function ViewUser({userId, load, user}) {
+  return (
+    <div>
+      <button onClick={() => load(userId)}>Load User Info</button>
+      {user && <UserData data={user} />}
+    </div>
+  )
+}
+
+export default connect(state => ({ user: getData(state)}), { load })(ViewUser)
 ```
+
 
 And that's it! That's all you need to do; no need to manually create or place a subreducer
 anywhere. The subreducer is pretty basic, it holds the return of `load` in the data attribute.
@@ -104,17 +92,16 @@ import thunk from 'redux-thunk';
 
 import { combineAsyncReducers, configureRags } from 'redux-rags';
 
-// ... import a few reducers; we'll use userReducer as an example
+// Import a few reducers like you normally would to create a top level reducer: we'll use `userReducer` as an example
 import userReducer from './userReducer';
 
 const createRootReducer = (dynamicReducers: Object = {}) => {
   dynamicReducers = combineAsyncReducers(combineReducers, dynamicReducers);
 
-  return combineReducers({
-    ...dynamicReducers,
+  return combineReducers(Object.assign({}, dynamicReducers, {
     // Then list your reducers below
     userReducer
-  });
+  }));
 }
 
 const middleware = applyMiddleware(thunk);
@@ -138,8 +125,8 @@ Actions are implementations of commonly used features to manipulate the state. M
 - `errors`: Sets the errors meta value.
 - `clearErrors`: Clears the errors meta value.
 - `updateData`: Sets the data value for the subreducer.
-- `update`: Thunk. Calls the `update` function passed in to `ragsFactory` and sets the data value to the result. Might also set the error attribute if the `update` function throws an error.
-- `load`: Thunk. Calls the appropriate sequence of `beginLoading`, `updateData`, `endLoading` actions while calling the `load` function passed to `ragsFactory`. If there are errors while executing, the error meta value will be set.
+- `update`: Thunk. Calls the `update` function passed in to `ragsFactory` and sets the data value to the result. Might also set the error attribute if the `update` function throws an error. Passed in function should look like: `(dataValue, ...params) => newData`. Returned func has signature: `(...params) => newData`. This is because the current data value will be added to the function internally.
+- `load`: Thunk. Calls the appropriate sequence of `beginLoading`, `updateData`, `endLoading` actions while calling the `load` function passed to `ragsFactory`. If there are errors while executing, the error meta value will be set. Passed in function looks like: `(...params) => newData`, returned function looks like `(...params) => newData`.
 
 ## Details and explanations of exports
 
@@ -217,32 +204,59 @@ The `ragFactoryMap` builds on top of `ragFactory`. That factory is used internal
 
 ## Additional Examples
 
-### Single File Redux Connection Example
-Here we want to hit an endpoint with the `userId` parameter. We'll avoid worrying about
-loading states or anything for now. The call to `ragFactory` creates the actions and injects
-the subreducer for us. Then this state information is stored in Redux, so when users return to the
-component they'll see the cached data. [Play with a similar example on CodeSandbox](https://codesandbox.io/s/vnn9pnp6vl)
+### Defining the Redux interactions in a separate file and importing
+We'll use a basic fetch for this example, hitting some json endpoint. The returned load function
+has the same signature as the function we passed in, so in this case `loadFaq` will not use
+any parameters.
+```js
+import { ragFactory } from 'redux-rags';
 
+const axiosLoadFaq = () => fetch('http://api.example.com/data.json');
+const { actions, getters } = ragFactory({ load: axiosLoadFaq });
+
+export {
+  loadFaq: actions.load,
+  getFaq: getters.getData,
+  getIsFaqLoading: getters.getIsLoading,
+};
+```
+
+#### Use that Data Request in a React Component
+Import the Getters and Action as you normally would and use them with `react-redux`. If you're used to
+defining thunks and getters in a different file and import them, then the code below should look
+remarkably similar to code that you've already seen or even written.
 ```js
 import React from 'react';
 import { connect } from 'react-redux';
-import { ragFactory } from 'redux-rags';
+import { loadFaq, getFaq, getIsFaqLoading } from './faqData';
+import Loading from './Loading';
+import FaqItem from './FaqItem';
 
-// Pass load to factory, factory returns a load that we can give to Redux, will have the same signature as the function we passed in.
-const { actions: { load }, getters: { getData } } = ragFactory({
-  load: (userId) => axios.get('/users', { userId })
-});
+class Faq extends React.Component {
+  componentDidMount() {
+    this.props.loadFaq();
+  }
 
-function ViewUser({userId, load, user}) {
-  return (
-    <div>
-      <button onClick={() => load(userId)}>Load User Info</button>
-      {user && <UserData data={user} />}
-    </div>
-  )
+  render() {
+    const { isLoading, faqData } = this.props;
+    if (isLoading) {
+      return <Loading />;
+    }
+
+    return (
+      <React.Fragment>
+        {faqData.map((data, index) => <FaqItem key={index} data={data} />}
+      </React.Fragment>
+    )
+  }
 }
 
-export default connect(state => ({ user: getData(state)}), { load })(ViewUser)
+const mapStateFromProps = state => ({
+  faqData: getFaq(state),
+  isLoading: getIsFaqLoading(state)
+});
+
+export default connect(mapStateFromProps, { loadFaq })(Faq);
 ```
 
 ### Placing the subreducer in a custom location in Redux
@@ -284,21 +298,25 @@ as a key for a different mini state machine.
  const { action: { load }, getters: { getData, getMeta } } =
    ragFactoryMap({ load: Function });
 
- // Somewhere else, maybe in a component after `load` was passed in through mapDispatchToProps.
+ // In a component after `load` was passed in through mapDispatchToProps.
 
- ...
- componentDidMount() {
-   const { loaded, load, taskId, userId } = this.props;
-   !loaded && load(userId, taskId);
- }
- ...
- mapStateToProps(state, props) {
-   const { userId, taskId } = props;
-   return {
-     loaded: getMeta(userId, taskId).loaded,
-     taskData: getData(userId, taskId)
-   }
- }
+class Component extends React.Component {
+  componentDidMount() {
+    const { loaded, load, taskId, userId } = this.props;
+    // Load the data for given userId and taskId if not loaded
+    !loaded && load(userId, taskId);
+  }
+  // ... Other functions of the class
+}
+
+function mapStateToProps(state, props) {
+  const { userId, taskId } = props;
+  return {
+    loaded: getMeta(userId, taskId).loaded,
+    taskData: getData(userId, taskId)
+  }
+}
+export default connect(mapStateToProps)(Component);
 ```
 
 ## License
@@ -306,5 +324,5 @@ MIT
 
 ## Thanks
 
-Huge thanks to Jimmy Shen for [this amazing Medium article](https://medium.com/@jimmy_shen/inject-reducer-arbitrarily-rather-than-top-level-for-redux-store-to-replace-reducer-fdc1060a6a7)
+Huge thanks to Jimmy Shen for [the amazing Medium article already linked above](https://medium.com/@jimmy_shen/inject-reducer-arbitrarily-rather-than-top-level-for-redux-store-to-replace-reducer-fdc1060a6a7)
 on dynamically injecting reducers into the Redux store.


### PR DESCRIPTION
Partially addressed some feedback on the readme. Outstanding comments:

- [x] Avoid destructuring in examples, it's increased cognitive load and unfamiliar to some
- [ ] Argument explanation of `load` and `update` thunks. What do they take in? How does it differ from the function I passed?
- [x] First example should be single file usage, not multiple file. 
- [x] Explain a little bit what injecting a reducer means, what it does for you. Maybe write a separate doc page / post about the difference between defining reducers the old way vs using this package.

Suggestions / Responses:
- Rename `getIsLoading` getter to `isLoading`?
 `isLoading` may potentially be a confusing name for the function to query the `isLoading` state of data. We'd be overloading the term 'isLoading', as in some contexts it would refer to the function and in others  to the boolean property. `getIsLoading` is a little clunky, but I think the distinction between the `getter` and the property is important to highlight.
- Can we handle `redux-thunk` internally?
I really don't think we can do that. The Redux middleware hookup is supposed to only happen once, and if we do some things internally, it would modify the store in a much more significant way. Since we're asking for the reference, it might be possible to dig in and modify the middleware array, injecting `redux-thunk` if it isn't there. Since `redux-thunk` is a pretty popular addition to Redux, I don't think it's too much to say that as a user you should also apply `redux-thunk` to use this package. Chances are someone already has that hooked up.